### PR TITLE
Fix vaccine data graph overflow, back-fill missing vaccine data, and add sync tooltips

### DIFF
--- a/components/ChartContainer.js
+++ b/components/ChartContainer.js
@@ -15,6 +15,7 @@ const ChartContainer = ({
 	dataSource = [],
 	title,
 	syncId,
+	xAxisScale,
 }) => {
 	return (
 		<div className="tl dib chart-container w-100">
@@ -34,7 +35,7 @@ const ChartContainer = ({
 						/>
 					)}
 					<CartesianGrid vertical={false} />
-					<XAxis dataKey={dataKeyX} />
+					<XAxis dataKey={dataKeyX} scale={xAxisScale} />
 					<YAxis type="number" domain={[0, 'auto']} />
 					<Tooltip />
 					{bars.map(bar => (

--- a/components/ChartContainer.js
+++ b/components/ChartContainer.js
@@ -14,6 +14,7 @@ const ChartContainer = ({
 	dataKeyX = "date_string",
 	dataSource = [],
 	title,
+	syncId,
 }) => {
 	return (
 		<div className="tl dib chart-container w-100">
@@ -24,7 +25,7 @@ const ChartContainer = ({
 				</strong>
 			</div>
 			<ResponsiveContainer width="95%" height={400} className="mt16">
-				<ComposedChart data={dataSource}>
+				<ComposedChart data={dataSource} syncId={syncId} >
 					{(bars.length + lines.length) > 1 && (
 						<Legend
 							layout="horizontal"

--- a/lib/getVaccineData.js
+++ b/lib/getVaccineData.js
@@ -13,7 +13,6 @@ const getVaccineData = () => (
 			for (let currentRecordIndex = 1; currentRecordIndex < rawRecords.length; currentRecordIndex++) {
 				// Backfill up to, but not including, the current record
 				let currentRecord = rawRecords[currentRecordIndex]
-				if (!currentRecord) debugger
 				const curRecordTime = new Date(currentRecord.report_date).getTime()
 
 				// Always add the previous record in the original data set

--- a/lib/getVaccineData.js
+++ b/lib/getVaccineData.js
@@ -5,8 +5,39 @@ const dataUrl = 'https://data.ontario.ca/api/3/action/datastore_search?resource_
 const getVaccineData = () => (
 	new Promise((resolve) => {
 		jsonpFetch(dataUrl, ({ result }) => {
-			const records = result.records;
-			records.sort((a,b) => new Date(a.report_date) - new Date(b.report_date));
+			const rawRecords = result.records;
+			rawRecords.sort((a,b) => new Date(a.report_date) - new Date(b.report_date));
+
+			// Data comes in with gaps for some dates, so fill in the gaps by replicating the previous date's data
+			const records = []
+			for (let currentRecordIndex = 1; currentRecordIndex < rawRecords.length; currentRecordIndex++) {
+				// Backfill up to, but not including, the current record
+				let currentRecord = rawRecords[currentRecordIndex]
+				if (!currentRecord) debugger
+				const curRecordTime = new Date(currentRecord.report_date).getTime()
+
+				// Always add the previous record in the original data set
+				let prevRecord = rawRecords[currentRecordIndex - 1]
+				records.push(prevRecord)
+
+				// Continue adding copies of the previous record, until it matches the current record
+				let dateToFill = new Date(prevRecord.report_date)
+				dateToFill.setDate(dateToFill.getDate() + 1)
+
+				while(dateToFill.getTime() < curRecordTime) {
+					// Create a new record with a date to fill
+					const backfillRecord = Object.assign({}, prevRecord, { report_date: dateToFill.toISOString().replace(/\.\d+Z/, "")})
+					records.push(backfillRecord)
+
+					// Update the date to fill
+					dateToFill.setDate(dateToFill.getDate() + 1)
+				}
+			}
+
+			// Add the last record, which wasn't added by the above loop
+			records.push(rawRecords[rawRecords.length - 1])
+
+			// Back to your regularly scheduled code
 			records.map(record => {
 				const { report_date, total_doses_administered } = record;
 				record.date_string = new Date(report_date).toLocaleString('en-us', {

--- a/pages/index.js
+++ b/pages/index.js
@@ -60,6 +60,7 @@ function HomePage() {
 				<ChartContainer
 					key={index}
 					dataSource={data}
+					syncId="syncCharts"
 					{...chart}
 				/>
 			))}

--- a/pages/index.js
+++ b/pages/index.js
@@ -50,6 +50,7 @@ function HomePage() {
 				dataSource={vaccineData}
 				dataKeyX="date_string"
 				title="Vaccinations"
+				xAxisScale="band" // This forces the bars of the vaccine graph to stay within the bounds of the axis
 				bars={[{
 					dataKey: 'total_doses_administered',
 					name: 'Total doses administered',
@@ -60,7 +61,7 @@ function HomePage() {
 				<ChartContainer
 					key={index}
 					dataSource={data}
-					syncId="syncCharts"
+					syncId="syncCharts" // This shows tooltips for all the OntarioStatuses charts
 					{...chart}
 				/>
 			))}


### PR DESCRIPTION
1. The vaccine graph needs a `scale="band"` so it doesn't overflow
2. The vaccine data was missing some dates in December which made it misleading at a glance

![image](https://user-images.githubusercontent.com/326184/107100077-4baf1500-67e1-11eb-8511-65c7ea5addb3.png)

3. Added synchronized tooltips for all the other graphs

![image](https://user-images.githubusercontent.com/326184/107100139-8153fe00-67e1-11eb-837c-156485114b69.png)
