### PR TITLE
Make Vaccinations area too

### DIFF
--- a/components/ChartContainer.js
+++ b/components/ChartContainer.js
@@ -15,6 +15,7 @@ const ChartContainer = ({
 	dataSource = [],
 	title,
 	syncId,
+	xAxisScale,
 }) => {
 	return (
 		<div className="tl dib chart-container w-100">

--- a/components/ChartContainer.js
+++ b/components/ChartContainer.js
@@ -15,7 +15,6 @@ const ChartContainer = ({
 	dataSource = [],
 	title,
 	syncId,
-	xAxisScale,
 }) => {
 	return (
 		<div className="tl dib chart-container w-100">

--- a/components/ChartContainer.js
+++ b/components/ChartContainer.js
@@ -15,7 +15,6 @@ const ChartContainer = ({
 	dataSource = [],
 	title,
 	syncId,
-	xAxisScale,
 }) => {
 	return (
 		<div className="tl dib chart-container w-100">
@@ -35,7 +34,7 @@ const ChartContainer = ({
 						/>
 					)}
 					<CartesianGrid vertical={false} />
-					<XAxis dataKey={dataKeyX} scale={xAxisScale} />
+					<XAxis dataKey={dataKeyX} />
 					<YAxis type="number" domain={[0, 'auto']} />
 					<Tooltip formatter={(value) => value.toLocaleString()} />
 					{bars.map(bar => (

--- a/pages/index.js
+++ b/pages/index.js
@@ -66,7 +66,7 @@ function HomePage() {
 				<ChartContainer
 					key={index}
 					dataSource={data}
-					syncId="syncCharts" // This shows tooltips for all the OntarioStatuses charts
+					syncId="syncCharts"
 					{...chart}
 				/>
 			))}

--- a/pages/index.js
+++ b/pages/index.js
@@ -66,7 +66,7 @@ function HomePage() {
 				<ChartContainer
 					key={index}
 					dataSource={data}
-					syncId="syncCharts"
+					syncId="syncCharts" // This shows tooltips for all the OntarioStatuses charts
 					{...chart}
 				/>
 			))}

--- a/pages/index.js
+++ b/pages/index.js
@@ -55,8 +55,7 @@ function HomePage() {
 				dataSource={vaccineData}
 				dataKeyX="date_string"
 				title="Vaccinations"
-				xAxisScale="band" // This forces the bars of the vaccine graph to stay within the bounds of the axis
-				bars={[{
+				areas={[{
 					dataKey: 'total_doses_administered',
 					name: 'Total doses administered',
 					fill: '#509ee3',


### PR DESCRIPTION
I realized vaccinations are also totals, so rather than playing around with the `scale` param which may potentially cause trouble later when the bars start to get small it would be easier and more consistent to just make it an area graph too.

![image](https://user-images.githubusercontent.com/326184/107244888-86d96000-69fc-11eb-8197-6c6e948f04b2.png)
