### PR TITLE
Speed up stats, cache result data for 8 hours, and add a few extra graphs

### DIFF
--- a/src/chartConfig/cases/ageBreakdown.js
+++ b/src/chartConfig/cases/ageBreakdown.js
@@ -19,7 +19,7 @@ const ageBreakdown = {
 	}]
 };
 
-export const youngerMonthlyBreakdown = {
+export const youngerMonthlyDeathBreakdown = {
 	title: 'Deaths by age group 0-50s',
 	dataKeyX: 'month',
 	lines: [{
@@ -54,7 +54,7 @@ export const youngerMonthlyBreakdown = {
 	}]
 };
 
-export const olderMonthlyBreakdown = {
+export const olderMonthlyDeathBreakdown = {
 	title: 'Deaths by age group 50s-90s+',
 	dataKeyX: 'month',
 	lines: [
@@ -90,6 +90,63 @@ export const olderMonthlyBreakdown = {
 	}]
 };
 
-
+export const monthlyRecoveryBreakdown = {
+	title: 'All monthly recoveries',
+	dataKeyX: 'month',
+	lines: [{
+		dataKey: '<20-resolved',
+		fill: '#21660b',
+		stroke: '#21660b',
+		name: '<20',
+	},
+	{
+		dataKey: '20s-resolved',
+		fill: '#5f884a',
+		stroke: '#5f884a',
+		name: '20s',
+	},
+	{
+		dataKey: '30s-resolved',
+		fill: '#5b796a',
+		stroke: '#5b796a',
+		name: '30s',
+	},
+	{
+		dataKey: '40s-resolved',
+		fill: '#737a69',
+		stroke: '#737a69',
+		name: '40s',
+	},
+	{
+		dataKey: '50s-resolved',
+		fill: '#000000',
+		stroke: '#000000',
+		name: '50s',
+	},
+	{
+		dataKey: '60s-resolved',
+		fill: '#3d3cff',
+		stroke: '#3d3cff',
+		name: '60s',
+	},
+	{
+		dataKey: '70s-resolved',
+		fill: '#9552f9',
+		stroke: '#9552f9',
+		name: '70s',
+	},
+	{
+		dataKey: '80s-resolved',
+		fill: '#20e0ff',
+		stroke: '#20e0ff',
+		name: '80s',
+	},
+	{
+		dataKey: '90+-resolved',
+		fill: '#de425b',
+		stroke: '#de425b',
+		name: '90+',
+	}]
+};
 
 export default ageBreakdown;

--- a/src/chartConfig/cases/ageBreakdown.js
+++ b/src/chartConfig/cases/ageBreakdown.js
@@ -19,4 +19,77 @@ const ageBreakdown = {
 	}]
 };
 
+export const youngerMonthlyBreakdown = {
+	title: 'Deaths by age group 0-50s',
+	dataKeyX: 'month',
+	lines: [{
+		dataKey: '<20-deceased',
+		fill: '#21660b',
+		stroke: '#21660b',
+		name: '<20',
+	},
+	{
+		dataKey: '20s-deceased',
+		fill: '#5f884a',
+		stroke: '#5f884a',
+		name: '20s',
+	},
+	{
+		dataKey: '30s-deceased',
+		fill: '#5b796a',
+		stroke: '#5b796a',
+		name: '30s',
+	},
+	{
+		dataKey: '40s-deceased',
+		fill: '#737a69',
+		stroke: '#737a69',
+		name: '40s',
+	},
+	{
+		dataKey: '50s-deceased',
+		fill: '#000000',
+		stroke: '#000000',
+		name: '50s',
+	}]
+};
+
+export const olderMonthlyBreakdown = {
+	title: 'Deaths by age group 50s-90s+',
+	dataKeyX: 'month',
+	lines: [
+	{
+		dataKey: '50s-deceased',
+		fill: '#000000',
+		stroke: '#000000',
+		name: '50s',
+	},
+	{
+		dataKey: '60s-deceased',
+		fill: '#3d3cff',
+		stroke: '#3d3cff',
+		name: '60s',
+	},
+	{
+		dataKey: '70s-deceased',
+		fill: '#9552f9',
+		stroke: '#9552f9',
+		name: '70s',
+	},
+	{
+		dataKey: '80s-deceased',
+		fill: '#20e0ff',
+		stroke: '#20e0ff',
+		name: '80s',
+	},
+	{
+		dataKey: '90+-deceased',
+		fill: '#de425b',
+		stroke: '#de425b',
+		name: '90+',
+	}]
+};
+
+
+
 export default ageBreakdown;

--- a/src/chartConfig/index.js
+++ b/src/chartConfig/index.js
@@ -12,7 +12,11 @@ import totalDoses from './vaccinations/totalDoses';
 import dailyDoses from './vaccinations/dailyDoses';
 import totalVaccinated from './vaccinations/totalVaccinated';
 
-import ageBreakdown, { youngerMonthlyBreakdown, olderMonthlyBreakdown } from './cases/ageBreakdown';
+import ageBreakdown, {
+  youngerMonthlyDeathBreakdown,
+  olderMonthlyDeathBreakdown,
+  monthlyRecoveryBreakdown,
+} from './cases/ageBreakdown';
 
 export const ontarioStatusCharts = [
 	activeCases,
@@ -35,6 +39,7 @@ export const vaccineCharts = [
 export const ageStats = ageBreakdown;
 
 export const monthlyAgeBreakdowns = [
-  youngerMonthlyBreakdown,
-  olderMonthlyBreakdown
+  youngerMonthlyDeathBreakdown,
+  olderMonthlyDeathBreakdown,
+  monthlyRecoveryBreakdown,
 ];

--- a/src/chartConfig/index.js
+++ b/src/chartConfig/index.js
@@ -12,7 +12,7 @@ import totalDoses from './vaccinations/totalDoses';
 import dailyDoses from './vaccinations/dailyDoses';
 import totalVaccinated from './vaccinations/totalVaccinated';
 
-import ageBreakdown from './cases/ageBreakdown';
+import ageBreakdown, { youngerMonthlyBreakdown, olderMonthlyBreakdown } from './cases/ageBreakdown';
 
 export const ontarioStatusCharts = [
 	activeCases,
@@ -33,3 +33,8 @@ export const vaccineCharts = [
 ];
 
 export const ageStats = ageBreakdown;
+
+export const monthlyAgeBreakdowns = [
+  youngerMonthlyBreakdown,
+  olderMonthlyBreakdown
+];

--- a/src/data/getCaseData.js
+++ b/src/data/getCaseData.js
@@ -4,6 +4,7 @@ import jsonpFetch from './jsonpFetch';
  * API Fields
  *
  * @see getCaseDataTypes.ts
+ * @see https://docs.ckan.org/en/2.8/maintaining/datastore.html#ckanext.datastore.logic.action.datastore_search
  */
 const dataUrl = 'https://data.ontario.ca/api/3/action/datastore_search?resource_id=455fd63b-603d-4608-8216-7d8647f43350&fields=Outcome1,Accurate_Episode_Date,Age_Group&limit=1000000';
 
@@ -26,12 +27,12 @@ const ageGroups = [
  * Initialize an object with age groups in the above order
  */
 const initAgeGroupedRecord = () => {
-	const ageGroupedRecord = {}
+	const ageGroupedRecord = {};
 	ageGroups.forEach((ageGroup) => {
 		ageGroupedRecord[ageGroup] = { ageGroup, total: 0, deceased: 0, resolved: 0, active: 0 };
-	})
-	return ageGroupedRecord
-}
+	});
+	return ageGroupedRecord;
+};
 
 /**
  * Take an API response, and build a stats object
@@ -47,7 +48,7 @@ const compileAgeStats = (records) => {
 		const ageGroup = record.Age_Group;
 
 		// Only care about known age groups
-		if (ageGroup === "UNKNOWN") return;
+		if (ageGroup === 'UNKNOWN') return;
 
 		// Accurate_Episode_Date is a ISO 8601 date/time string
 		const yearMonth = record.Accurate_Episode_Date.substring(0, 7);
@@ -76,18 +77,18 @@ const compileAgeStats = (records) => {
 	});
 
 	// Convert data to arrays for recharts
-	const totalByAge = ageGroups.map((ageGroup) => totalByAgeParsed[ageGroup])
+	const totalByAge = ageGroups.map((ageGroup) => totalByAgeParsed[ageGroup]);
 
 	const monthyByAge = Object.entries(monthyByAgeParsed).sort(([monthA], [monthB]) => new Date(monthA) - new Date(monthB)).map(([month, monthlyByAgeGroup]) => {
-		const monthData = { month }
+		const monthData = { month };
 		Object.values(monthlyByAgeGroup).forEach(({ ageGroup, total, deceased, resoled, active }) => {
-			monthData[`${ageGroup}-total`] = total
-			monthData[`${ageGroup}-deceased`] = deceased
-			monthData[`${ageGroup}-resoled`] = resoled
-			monthData[`${ageGroup}-active`] = active
+			monthData[`${ageGroup}-total`] = total;
+			monthData[`${ageGroup}-deceased`] = deceased;
+			monthData[`${ageGroup}-resoled`] = resoled;
+			monthData[`${ageGroup}-active`] = active;
 		});
 
-		return monthData
+		return monthData;
 	});
 
 	return { totalByAge, monthyByAge };
@@ -95,10 +96,10 @@ const compileAgeStats = (records) => {
 
 
 // Should we use localStorage to cache the results
-const useLocalStorage = typeof(Storage) !== "undefined";
+const useLocalStorage = typeof(Storage) !== 'undefined';
 
 // The key to use to store the results
-const localStorageKey = "CACHED_getCaseDataResult";
+const localStorageKey = 'CACHED_getCaseDataResult';
 
 // How long should the cache last
 const cacheExpiryHours = 8;
@@ -117,7 +118,7 @@ const getCases = (fetcher = jsonpFetch) => {
 				const cachedCaseDataResult = JSON.parse(cachedCaseDataRaw);
 				if (currentDate.getTime() <= cachedCaseDataResult.expiry && cachedCaseDataResult.ageData) {
 					// Found cached result. Use that instead of fetching new data.
-					console.log(`Using cached result data localStorage. Clear storage key ${localStorageKey} to reset.`)
+					console.log(`Using cached result data localStorage. Clear storage key ${localStorageKey} to reset.`);
 					resolve(cachedCaseDataResult.ageData);
 					return;
 				}

--- a/src/data/getCaseData.js
+++ b/src/data/getCaseData.js
@@ -1,7 +1,15 @@
 import jsonpFetch from './jsonpFetch';
 
-const dataUrl = 'https://data.ontario.ca/api/3/action/datastore_search?resource_id=455fd63b-603d-4608-8216-7d8647f43350&limit=1000000';
+/**
+ * API Fields
+ *
+ * @see getCaseDataTypes.ts
+ */
+const dataUrl = 'https://data.ontario.ca/api/3/action/datastore_search?resource_id=455fd63b-603d-4608-8216-7d8647f43350&fields=Outcome1,Accurate_Episode_Date,Age_Group&limit=1000000';
 
+/**
+ * Sort ofder for age grouped data
+ */
 const ageGroups = [
 	'<20',
 	'20s',
@@ -14,44 +22,129 @@ const ageGroups = [
 	'90+',
 ];
 
+/**
+ * Initialize an object with age groups in the above order
+ */
+const initAgeGroupedRecord = () => {
+	const ageGroupedRecord = {}
+	ageGroups.forEach((ageGroup) => {
+		ageGroupedRecord[ageGroup] = { ageGroup, total: 0, deceased: 0, resolved: 0, active: 0 };
+	})
+	return ageGroupedRecord
+}
 
+/**
+ * Take an API response, and build a stats object
+ *
+ * * @see getCaseDataTypes.ts
+ */
 const compileAgeStats = (records) => {
-	const ages = {};
+  const totalByAgeParsed = initAgeGroupedRecord();
+  const monthyByAgeParsed = {};
+
 	records.forEach(record => {
+		// Make sure the age group is valid
 		const ageGroup = record.Age_Group;
-		if (!ages[ageGroup]) {
-			ages[ageGroup] = {
-				total: 1,
-				deceased: record.Outcome1 === 'Fatal' ? 1 : 0,
-				resolved: record.Outcome1 === 'Resolved' ? 1 : 0,
-				active: ['Fatal', 'Resolved'].includes(record.Outcome1) ? 1 : 0,
-			};
+
+		// Only care about known age groups
+		if (ageGroup === "UNKNOWN") return;
+
+		// Accurate_Episode_Date is a ISO 8601 date/time string
+		const yearMonth = record.Accurate_Episode_Date.substring(0, 7);
+
+		// Initialize missing data
+		if (!monthyByAgeParsed[yearMonth]) monthyByAgeParsed[yearMonth] = initAgeGroupedRecord();
+
+		// Get variable we'll be updating into scope
+		const ageGroupToUpdate = totalByAgeParsed[ageGroup];
+		const monthGroupToUpdat = monthyByAgeParsed[yearMonth][ageGroup];
+
+		// Update the lists
+		ageGroupToUpdate.total += 1;
+		monthGroupToUpdat.total += 1;
+
+		if (record.Outcome1 === 'Fatal') {
+			ageGroupToUpdate.deceased += 1;
+			monthGroupToUpdat.deceased += 1;
+		} else if (record.Outcome1 === 'Resolved') {
+			ageGroupToUpdate.resolved += 1;
+			monthGroupToUpdat.resolved += 1;
 		} else {
-			ages[ageGroup].total += 1;
-			const deceased = record.Outcome1 === 'Fatal' ? 1 : 0;
-			const resolved = record.Outcome1 === 'Resolved' ? 1 : 0;
-			ages[ageGroup].deceased += deceased;
-			ages[ageGroup].resolved += resolved;
-			ages[ageGroup].active += (1 - deceased - resolved);
+			ageGroupToUpdate.active += 1;
+			monthGroupToUpdat.active += 1;
 		}
 	});
 
-	return ageGroups.map((age) => ({
-		ageGroup: age,
-		deceased: ages[age].deceased,
-		resolved: ages[age].resolved,
-		active: ages[age].active,
-		total: ages[age].total,
-	}));
+	// Convert data to arrays for recharts
+	const totalByAge = ageGroups.map((ageGroup) => totalByAgeParsed[ageGroup])
+
+	const monthyByAge = Object.entries(monthyByAgeParsed).sort(([monthA], [monthB]) => new Date(monthA) - new Date(monthB)).map(([month, monthlyByAgeGroup]) => {
+		const monthData = { month }
+		Object.values(monthlyByAgeGroup).forEach(({ ageGroup, total, deceased, resoled, active }) => {
+			monthData[`${ageGroup}-total`] = total
+			monthData[`${ageGroup}-deceased`] = deceased
+			monthData[`${ageGroup}-resoled`] = resoled
+			monthData[`${ageGroup}-active`] = active
+		});
+
+		return monthData
+	});
+
+	return { totalByAge, monthyByAge };
 };
 
 
-const getCases = () => {
+// Should we use localStorage to cache the results
+const useLocalStorage = typeof(Storage) !== "undefined";
+
+// The key to use to store the results
+const localStorageKey = "CACHED_getCaseDataResult";
+
+// How long should the cache last
+const cacheExpiryHours = 8;
+
+/**
+ * Loads data for the stats screen
+ */
+const getCases = (fetcher = jsonpFetch) => {
 	return new Promise((resolve) => {
-		jsonpFetch(dataUrl, data => {
-			const ageData = compileAgeStats(data.result.records);
-			resolve(ageData);
-		});
+		if (useLocalStorage) {
+			// Try to get the old result from cache
+			const currentDate = new Date();
+
+			const cachedCaseDataRaw = localStorage.getItem(localStorageKey);
+			if (cachedCaseDataRaw) {
+				const cachedCaseDataResult = JSON.parse(cachedCaseDataRaw);
+				if (currentDate.getTime() <= cachedCaseDataResult.expiry && cachedCaseDataResult.ageData) {
+					// Found cached result. Use that instead of fetching new data.
+					console.log(`Using cached result data localStorage. Clear storage key ${localStorageKey} to reset.`)
+					resolve(cachedCaseDataResult.ageData);
+					return;
+				}
+			}
+
+			// Cached fetch failed, query original source
+			fetcher(dataUrl, data => {
+				const ageData = compileAgeStats(data.result.records);
+
+				// Save the new result to cache, with an expiry timer
+				const expiryDate = new Date(currentDate);
+				expiryDate.setHours(currentDate.getHours() + cacheExpiryHours);
+
+				localStorage.setItem(localStorageKey, JSON.stringify({
+					expiry: expiryDate.getTime(),
+					ageData,
+				}));
+
+				resolve(ageData);
+			});
+		} else {
+			// Local storage not available, just do the fetch
+			fetcher(dataUrl, data => {
+				const ageData = compileAgeStats(data.result.records);
+				resolve(ageData);
+			});
+		}
 	});
 };
 

--- a/src/data/getCaseData.js
+++ b/src/data/getCaseData.js
@@ -6,7 +6,7 @@ import jsonpFetch from './jsonpFetch';
  * @see getCaseDataTypes.ts
  * @see https://docs.ckan.org/en/2.8/maintaining/datastore.html#ckanext.datastore.logic.action.datastore_search
  */
-const dataUrl = 'https://data.ontario.ca/api/3/action/datastore_search?resource_id=455fd63b-603d-4608-8216-7d8647f43350&fields=Outcome1,Accurate_Episode_Date,Age_Group&limit=1000000';
+ const dataUrl = 'https://data.ontario.ca/api/3/action/datastore_search?resource_id=455fd63b-603d-4608-8216-7d8647f43350&fields=Outcome1,Accurate_Episode_Date,Age_Group&limit=1000000';
 
 /**
  * Sort ofder for age grouped data
@@ -81,10 +81,10 @@ const compileAgeStats = (records) => {
 
 	const monthyByAge = Object.entries(monthyByAgeParsed).sort(([monthA], [monthB]) => new Date(monthA) - new Date(monthB)).map(([month, monthlyByAgeGroup]) => {
 		const monthData = { month };
-		Object.values(monthlyByAgeGroup).forEach(({ ageGroup, total, deceased, resoled, active }) => {
+		Object.values(monthlyByAgeGroup).forEach(({ ageGroup, total, deceased, resolved, active }) => {
 			monthData[`${ageGroup}-total`] = total;
 			monthData[`${ageGroup}-deceased`] = deceased;
-			monthData[`${ageGroup}-resoled`] = resoled;
+			monthData[`${ageGroup}-resolved`] = resolved;
 			monthData[`${ageGroup}-active`] = active;
 		});
 
@@ -97,6 +97,8 @@ const compileAgeStats = (records) => {
 
 // Should we use localStorage to cache the results
 const useLocalStorage = typeof(Storage) !== 'undefined';
+
+const localStorageVersion = 'v3';
 
 // The key to use to store the results
 const localStorageKey = 'CACHED_getCaseDataResult';
@@ -116,7 +118,7 @@ const getCases = (fetcher = jsonpFetch) => {
 			const cachedCaseDataRaw = localStorage.getItem(localStorageKey);
 			if (cachedCaseDataRaw) {
 				const cachedCaseDataResult = JSON.parse(cachedCaseDataRaw);
-				if (currentDate.getTime() <= cachedCaseDataResult.expiry && cachedCaseDataResult.ageData) {
+				if (currentDate.getTime() <= cachedCaseDataResult.expiry && cachedCaseDataResult.ageData && cachedCaseDataResult[localStorageVersion]) {
 					// Found cached result. Use that instead of fetching new data.
 					console.log(`Using cached result data localStorage. Clear storage key ${localStorageKey} to reset.`);
 					resolve(cachedCaseDataResult.ageData);
@@ -133,6 +135,7 @@ const getCases = (fetcher = jsonpFetch) => {
 				expiryDate.setHours(currentDate.getHours() + cacheExpiryHours);
 
 				localStorage.setItem(localStorageKey, JSON.stringify({
+          [localStorageVersion]: true,
 					expiry: expiryDate.getTime(),
 					ageData,
 				}));

--- a/src/data/getCaseData.js
+++ b/src/data/getCaseData.js
@@ -98,6 +98,7 @@ const compileAgeStats = (records) => {
 // Should we use localStorage to cache the results
 const useLocalStorage = typeof(Storage) !== 'undefined';
 
+// Update this version to force a reload, regardless of exiry timeout
 const localStorageVersion = 'v3';
 
 // The key to use to store the results

--- a/src/data/getCaseDataTypes.ts
+++ b/src/data/getCaseDataTypes.ts
@@ -1,5 +1,9 @@
 /**
- * The fields returned by the API
+ * This file is purely informational. It describes the result payload for the Ontario COVID-19 outcome API.
+ */
+
+/**
+ * The various field types returned by the API
  */
 enum TimestampFields {
   Accurate_Episode_Date = "Accurate_Episode_Date",
@@ -34,15 +38,15 @@ enum EnumStringFields {
  * Enums used by EnumStringFields
  */
 enum AgeGroups {
-  under20 = "<20",
-  over20 = "20s",
-  over30 = "30s",
-  over40 = "40s",
-  over50 = "50s",
-  over60 = "60s",
-  over70 = "70s",
-  over80 = "80s",
-  over90 = "90+",
+  Under20 = "<20",
+  Over20 = "20s",
+  Over30 = "30s",
+  Over40 = "40s",
+  Over50 = "50s",
+  Over60 = "60s",
+  Over70 = "70s",
+  Over80 = "80s",
+  Over90 = "90+",
 }
 
 enum OutbreakRelated {

--- a/src/data/getCaseDataTypes.ts
+++ b/src/data/getCaseDataTypes.ts
@@ -1,0 +1,121 @@
+/**
+ * The fields returned by the API
+ */
+enum TimestampFields {
+  Accurate_Episode_Date = "Accurate_Episode_Date",
+  Case_Reported_Date = "Case_Reported_Date",
+  Test_Reported_Date = "Test_Reported_Date",
+  Specimen_Date = "Specimen_Date",
+}
+
+enum NumberFields {
+  Row_ID = "Row_ID",
+  Reporting_PHU_ID = "Reporting_PHU_ID",
+  Reporting_PHU_Latitude = "Reporting_PHU_Latitude",
+  Reporting_PHU_Longitude = "Reporting_PHU_Longitude",
+}
+
+enum DataStringFields {
+  Row_ID = "Row_ID",
+  Reporting_PHU_ID = "Reporting_PHU_ID",
+  Reporting_PHU_Latitude = "Reporting_PHU_Latitude",
+  Reporting_PHU_Longitude = "Reporting_PHU_Longitude",
+}
+
+enum EnumStringFields {
+  Age_Group = "Age_Group",
+  Case_AcquisitionInfo = "Case_AcquisitionInfo",
+  Client_Gender = "Client_Gender",
+  Outcome1 = "Outcome1",
+  Outbreak_Related = "Outbreak_Related",
+}
+
+/**
+ * Enums used by EnumStringFields
+ */
+enum AgeGroups {
+  under20 = "<20",
+  over20 = "20s",
+  over30 = "30s",
+  over40 = "40s",
+  over50 = "50s",
+  over60 = "60s",
+  over70 = "70s",
+  over80 = "80s",
+  over90 = "90+",
+}
+
+enum OutbreakRelated {
+  Yes = "Yes",
+  No = "No",
+}
+
+enum AcquisitionInfo {
+  CC = "CC",
+  OB = "OB",
+  TRAVEL = "TRAVEL",
+  NO_KNOWN_EPI_LINK = "NO KNOWN EPI LINK",
+  MISSING_INFORMATION = "MISSING INFORMATION",
+  UNSPECIFIED_EPI_LINK = "UNSPECIFIED EPI LINK",
+}
+
+enum Outcomes {
+  Resolved = "Resolved",
+  Fatal = "Fatal",
+  NotResolved = "Not Resolved",
+}
+
+enum Genders {
+  Female = "FEMALE",
+  Male = "MALE",
+  GenderDiverse = "GENDER DIVERSE",
+  Unspecified = "UNSPECIFIED",
+}
+
+/**
+ * The actual API result
+ */
+interface ApiResult {
+  help: string;
+  success: boolean;
+  result: {
+    include_total: boolean;
+    resource_id: "455fd63b-603d-4608-8216-7d8647f43350";
+    fields: Array<
+      | { type: "int"; id: "_id" }
+      | {
+          info: { notes: ""; type_override: "timestamp"; label: "" };
+          type: "timestamp";
+          id: TimestampFields;
+        }
+      | {
+          info: { notes: ""; type_override: ""; label: "" };
+          type: "text";
+          id: EnumStringFields | DataStringFields;
+        }
+      | {
+          info: { notes: ""; type_override: "numeric"; label: "" };
+          type: "numeric";
+          id: NumberFields;
+        }
+    >;
+    records_format: "objects";
+    records: Array<
+      {
+        [EnumStringFields.Age_Group]?: AgeGroups;
+        [EnumStringFields.Outcome1]?: Outcomes;
+        [EnumStringFields.Case_AcquisitionInfo]?: AcquisitionInfo;
+        [EnumStringFields.Outbreak_Related]?: OutbreakRelated;
+        [EnumStringFields.Client_Gender]?: Genders;
+      } & Partial<Record<TimestampFields, string>> &
+        Partial<Record<DataStringFields, string>> &
+        Partial<Record<NumberFields, number>>
+    >;
+    limit: number;
+    _links: {
+      start: string;
+      next: string;
+    };
+    total: number;
+  };
+}

--- a/src/data/nodeFetch.js
+++ b/src/data/nodeFetch.js
@@ -1,0 +1,18 @@
+import https from "https"
+
+const nodeFetch = (url, callback) => {
+  https.get(url, (result) => {
+    let data = [];
+
+    result.on('data', chunk => {
+      data.push(chunk);
+    });
+
+    result.on('end', () => {
+      callback(JSON.parse(Buffer.concat(data).toString()))
+    });
+  }).on('error', err => {
+    console.error('Error: ', err.message);
+  });
+}
+export default nodeFetch

--- a/src/data/nodeFetch.js
+++ b/src/data/nodeFetch.js
@@ -1,4 +1,4 @@
-import https from "https"
+import https from 'https';
 
 const nodeFetch = (url, callback) => {
   https.get(url, (result) => {
@@ -9,10 +9,10 @@ const nodeFetch = (url, callback) => {
     });
 
     result.on('end', () => {
-      callback(JSON.parse(Buffer.concat(data).toString()))
+      callback(JSON.parse(Buffer.concat(data).toString()));
     });
   }).on('error', err => {
     console.error('Error: ', err.message);
   });
-}
-export default nodeFetch
+};
+export default nodeFetch;

--- a/src/pages/stats.js
+++ b/src/pages/stats.js
@@ -6,15 +6,21 @@ import Typography from '@material-ui/core/Typography';
 import getCases from '../data/getCaseData';
 import ChartContainer from '../components/ChartContainer';
 import LayoutSimple from '../components/LayoutSimple';
-import { ageStats } from '../chartConfig';
+import { ageStats, monthlyAgeBreakdowns } from '../chartConfig';
+import { ContactSupportOutlined } from '@material-ui/icons';
 
 
 const StatsContainer = () => {
-	const [data, setData] = useState([]);
+	const [totalByAge, setTotalByAgeData] = useState([]);
+	const [monthlyByAge, setMonthlyByAgeData] = useState([]);
 	const [loading, setLoading] = useState(true);
 
 	const fetchData = async () => {
-		await getCases().then(setData);
+		await getCases().then((caseData) => {
+			setTotalByAgeData(caseData.totalByAge);
+			setMonthlyByAgeData(caseData.monthyByAge);
+		})
+
 		setLoading(false);
 	};
 
@@ -35,12 +41,23 @@ const StatsContainer = () => {
 					</p>
 				</div>
 			) : (
-				<ChartContainer
-					dataSource={data}
-					xAxisScale="band"
-					{...ageStats}
-				/>
+				<>
+					<ChartContainer
+						dataSource={totalByAge}
+						xAxisScale="band"
+						{...ageStats}
+					/>
+					{monthlyAgeBreakdowns.map((chart, index) =>
+						<ChartContainer
+						key={index}
+						dataSource={monthlyByAge}
+						{...chart}
+					/>
+					)}
+				</>
 			)}
+
+
 		</LayoutSimple>
 	);
 };

--- a/src/pages/stats.js
+++ b/src/pages/stats.js
@@ -7,7 +7,6 @@ import getCases from '../data/getCaseData';
 import ChartContainer from '../components/ChartContainer';
 import LayoutSimple from '../components/LayoutSimple';
 import { ageStats, monthlyAgeBreakdowns } from '../chartConfig';
-import { ContactSupportOutlined } from '@material-ui/icons';
 
 
 const StatsContainer = () => {
@@ -19,7 +18,7 @@ const StatsContainer = () => {
 		await getCases().then((caseData) => {
 			setTotalByAgeData(caseData.totalByAge);
 			setMonthlyByAgeData(caseData.monthyByAge);
-		})
+		});
 
 		setLoading(false);
 	};


### PR DESCRIPTION
The stats screen was super slow because it was getting way more data than it needed. This PR speeds up the query, caches the results for 8 hours, and collects a bit more extra data (see below).

![image](https://user-images.githubusercontent.com/326184/114409344-5c309280-9b78-11eb-9668-c4cea62cf6eb.png)

Note, the most optimal way to do this would be to set up a scheduled action in your github.io repo. This could run every once in a while to update the stats file, which would make loading it almost instant.

```yaml
name: Rebuild File

on:
  schedule:
    - cron: 40 */8 * * * # Run at 00:40, 8:40, and 16:40
  workflow_dispatch:

jobs:
  build:
    runs-on: ubuntu-latest
    steps:
      # Checks-out your repository
      - uses: actions/checkout@v2

      # Install Node 14
      - uses: actions/setup-node@v2
        with:
          node-version: '14'
            
      # Run a node command to generate the data file
      - name: Run a one-line script
        run: node bin/callGetCaseData.js > data/caseData.json
      
      # Save changes
      - uses: EndBug/add-and-commit@v7
        with:
          author_name: Commit Bot
          author_email: bot@example.com
          branch: master
          message: Update caseData.json file on github.io
```