### PR TITLE
Handle numeric vaccine data

### DIFF
--- a/src/data/getVaccineData.js
+++ b/src/data/getVaccineData.js
@@ -7,7 +7,7 @@ const ensureNumber = (value) => {
     if (typeof value === 'number') {
         return value;
     }
-    return Number((value|| '0').replace(/,/g, ''));
+    return Number((value || '0').replace(/,/g, ''));
 };
 
 const getVaccineData = () =>

--- a/src/data/getVaccineData.js
+++ b/src/data/getVaccineData.js
@@ -3,6 +3,13 @@ import jsonpFetch from './jsonpFetch';
 const dataUrl =
   'https://data.ontario.ca/api/3/action/datastore_search?resource_id=8a89caa9-511c-4568-af89-7f2174b4378c&limit=100000';
 
+const ensureNumber = (value) => {
+    if (typeof value === 'number') {
+        return value;
+    }
+    return Number((value|| '0').replace(/,/g, ''));
+};
+
 const getVaccineData = () =>
   new Promise((resolve) => {
     jsonpFetch(dataUrl, ({ result }) => {
@@ -52,10 +59,9 @@ const getVaccineData = () =>
           month: 'short',
           day: 'numeric',
         });
-        record.total_doses_administered = Number(total_doses_administered.replace(/,/g, ''));
-        record.previous_day_doses_administered = Number((previous_day_doses_administered || '0').replace(/,/g, ''));
-        record.total_individuals_fully_vaccinated = Number((total_individuals_fully_vaccinated || '0').replace(/,/g, ''));
-
+        record.total_doses_administered = ensureNumber(total_doses_administered);
+        record.previous_day_doses_administered = ensureNumber(previous_day_doses_administered);
+        record.total_individuals_fully_vaccinated = ensureNumber(total_individuals_fully_vaccinated);
 
         vaccines_last7days.shift();
         vaccines_last7days.push(record.previous_day_doses_administered);


### PR DESCRIPTION
Seems like sometimes the vaccine data is already a number. In those cases, the `.replace` fails.

Wrote a little helper function to address this.