### PR TITLE
Use Eligible Population Instead of Adults

### DIFF
--- a/src/components/VaccinationStatus.js
+++ b/src/components/VaccinationStatus.js
@@ -5,41 +5,47 @@ const VaccinationStatus = ({ data = [] }) => {
 	if (!data.length) {
 		return null;
 	}
-
-	const population = 11602097;
+	// Population estimates on July 1st 2020 according to Statistics Canada
+	const populationBetween12and18 = 961342
+	const adultPopulation = 11971129
+	const eligiblePopulation = populationBetween12and18 + adultPopulation;
 
 	const lastUpdate = data[data.length - 1];
 	const totalFullyVaccinated = lastUpdate.total_individuals_fully_vaccinated;
 	const totalsWithOneDose = lastUpdate.total_doses_administered - (2 * totalFullyVaccinated);
-	const timeToFullVaccination = ((population - totalFullyVaccinated) * 2 - totalsWithOneDose) / lastUpdate.new_vaccines_rolling_average;
-	const timeToOneDose = ((population - totalFullyVaccinated) - totalsWithOneDose) / lastUpdate.new_vaccines_rolling_average;
+	const timeToFullVaccination = ((eligiblePopulation - totalFullyVaccinated) * 2 - totalsWithOneDose) / lastUpdate.new_vaccines_rolling_average;
+	const timeToOneDose = ((eligiblePopulation - totalFullyVaccinated) - totalsWithOneDose) / lastUpdate.new_vaccines_rolling_average;
 
 	return (
 		<ContentContainer title="Vaccinations at a glance">
 			<ul>
 				<li>
 					<strong>
-						{Math.round(((totalsWithOneDose + totalFullyVaccinated) / population) * 100 * 100) / 100}%
+						{Math.round(((totalsWithOneDose + totalFullyVaccinated) / eligiblePopulation) * 100 * 100) / 100}%
 					</strong>
 					{' '}
-					of the <em>adult</em> population of Ontario has had at least one shot.*
+					of the <em>eligible</em> population of Ontario has had at least one shot.*
 					</li>
 				<li>
 					<strong>
-						{Math.round((totalFullyVaccinated / population) * 100 * 100) / 100}%
+						{Math.round((totalFullyVaccinated / eligiblePopulation) * 100 * 100) / 100}%
 					</strong>
 					{' '}
-					of the <em>adult</em> population of Ontario is fully vaccinated.*
+					of the <em>eligible</em> population of Ontario is fully vaccinated.*
 				</li>
 				<li>
 					At the current average pace of <strong>{lastUpdate.new_vaccines_rolling_average.toLocaleString()}</strong> shots per day.
-					We can deliver a single dose to every adult in <strong>{Math.round(timeToOneDose)} days.</strong> And
+					We can deliver a single dose to every eligible person in <strong>{Math.round(timeToOneDose)} days.</strong> And
 					reach full vaccination in <strong>{Math.round(timeToFullVaccination)} days.*</strong>
 				</li>
 			</ul>
 			<div className="mt16 f12">
+				*Eligible population: Everyone 12 and older based on estimates from Statistics Canada on July 1st 2020.
+				<br/>
 				*These numbers are all back-of-the-envolope estimates. Don't take them as fact.
 			</div>
+			
+			
 		</ContentContainer>
 	);
 };

--- a/src/components/VaccinationStatus.js
+++ b/src/components/VaccinationStatus.js
@@ -6,8 +6,8 @@ const VaccinationStatus = ({ data = [] }) => {
 		return null;
 	}
 	// Population estimates on July 1st 2020 according to Statistics Canada
-	const populationBetween12and18 = 961342
-	const adultPopulation = 11971129
+	const populationBetween12and18 = 961342;
+	const adultPopulation = 11971129;
 	const eligiblePopulation = populationBetween12and18 + adultPopulation;
 
 	const lastUpdate = data[data.length - 1];


### PR DESCRIPTION
I updated the numbers based on the latest data from Statistics Canada, and I used all of the eligible population (12+) instead of just adults (18+). 
This will be more accurate going forward since we did start vaccinating adolescents 12+, and it won't be possible to know what proportion of those that got vaccinated are 18+ only.