### PR TITLE
Show Type of Vaccine Dose in Daily Graph

### DIFF
--- a/src/chartConfig/vaccinations/dailyDoses.js
+++ b/src/chartConfig/vaccinations/dailyDoses.js
@@ -3,9 +3,19 @@ const dailyDoses = {
   title: 'Daily vaccines administered',
   bars: [
     {
-      dataKey: 'previous_day_doses_administered',
-      name: 'Daily doses administered',
+      dataKey: 'previous_day_first_doses_administered',
+      name: 'Daily first doses administered',
       fill: '#509ee3',
+    },
+    {
+      dataKey: 'previous_day_second_doses_administered',
+      name: 'Daily second doses administered',
+      fill: '#82ca9d',
+    },
+    {
+      dataKey: 'previous_day_one_shot_doses_administered',
+      name: 'Daily one-shot doses administered',
+      fill: '#ca82c8',
     },
   ],
   lines: [

--- a/src/components/ChartContainer.js
+++ b/src/components/ChartContainer.js
@@ -38,7 +38,7 @@ const ChartContainer = ({
 					/>
 					<Tooltip formatter={(value) => value.toLocaleString()} />
 					{bars.map(bar => (
-						<Bar key={bar.dataKey} {...bar} />
+						<Bar key={bar.dataKey} stackId='a' {...bar} />
 					))}
 					{lines.map((line) => (
 						<Line key={line.dataKey} {...line} />

--- a/src/data/getVaccineData.js
+++ b/src/data/getVaccineData.js
@@ -70,7 +70,7 @@ const getVaccineData = () =>
         const total_doses_in_fully_vax = ensureNumber(total_doses_in_fully_vaccinated_individuals);
         
         // Calculate one-shot doses given (JnJ vaccine)
-        let total_one_shot_doses_administered = (record.total_individuals_fully_vaccinated - (total_doses_in_fully_vax/2)) * 2;
+        let total_one_shot_doses_administered = (record.total_individuals_fully_vaccinated - (total_doses_in_fully_vax / 2)) * 2;
         total_one_shot_doses_administered = total_one_shot_doses_administered > 1 ? total_one_shot_doses_administered : 0;
         
         let daily_one_shot_doses_administered = total_one_shot_doses_administered - previous_total_one_shot_doses_administered;

--- a/src/data/getVaccineData.js
+++ b/src/data/getVaccineData.js
@@ -47,12 +47,16 @@ const getVaccineData = () =>
       // Add the last record, which wasn't added by the above loop
       records.push(rawRecords[rawRecords.length - 1]);
 
+      let previous_total_second_doses_administered = 0;
+      let previous_total_one_shot_doses_administered = 0;
+
       // Back to your regularly scheduled code
       records.map((record) => {
         const {
           report_date,
           total_doses_administered,
           previous_day_doses_administered,
+          total_doses_in_fully_vaccinated_individuals,
           total_individuals_fully_vaccinated,
         } = record;
         record.date_string = new Date(report_date).toLocaleString('en-us', {
@@ -62,6 +66,28 @@ const getVaccineData = () =>
         record.total_doses_administered = ensureNumber(total_doses_administered);
         record.previous_day_doses_administered = ensureNumber(previous_day_doses_administered);
         record.total_individuals_fully_vaccinated = ensureNumber(total_individuals_fully_vaccinated);
+        
+        const total_doses_in_fully_vax = ensureNumber(total_doses_in_fully_vaccinated_individuals);
+        
+        // Calculate one-shot doses given (JnJ vaccine)
+        let total_one_shot_doses_administered = (record.total_individuals_fully_vaccinated - (total_doses_in_fully_vax/2)) * 2;
+        total_one_shot_doses_administered = total_one_shot_doses_administered > 1 ? total_one_shot_doses_administered : 0;
+        
+        let daily_one_shot_doses_administered = total_one_shot_doses_administered - previous_total_one_shot_doses_administered;
+        daily_one_shot_doses_administered = daily_one_shot_doses_administered > 0 ? daily_one_shot_doses_administered : 0;
+        previous_total_one_shot_doses_administered = total_one_shot_doses_administered;
+
+        // Calculate second doses given
+        let total_second_doses_administered = Math.floor((total_doses_in_fully_vax - total_one_shot_doses_administered) / 2);
+        const daily_second_doses_administered = total_second_doses_administered - previous_total_second_doses_administered;
+        previous_total_second_doses_administered = total_second_doses_administered;
+
+        // Calculate first doses given 
+        const daily_first_doses_administered = record.previous_day_doses_administered - (daily_second_doses_administered + daily_one_shot_doses_administered); 
+
+        record.previous_day_one_shot_doses_administered = daily_one_shot_doses_administered;
+        record.previous_day_second_doses_administered = daily_second_doses_administered;
+        record.previous_day_first_doses_administered =  daily_first_doses_administered;
 
         vaccines_last7days.shift();
         vaccines_last7days.push(record.previous_day_doses_administered);


### PR DESCRIPTION
I made some changes to show the different types of doses administered in the daily vaccination graph. 

The 3 types of doses are: 
- First dose 
- Second Dose
- One-shot Dose (J&J)

There's obviously no one-shot doses yet, but I just added it in anticipation. 

*The math might look complex, but it makes sense if you write it down on a paper. 

Screenshot: 
![Screen Shot](https://user-images.githubusercontent.com/7216646/119262107-b6def480-bbe2-11eb-95f5-e69a2a40cfbf.png)
