### PR TITLE
Show daily vaccine effectiveness

### DIFF
--- a/src/chartConfig/index.js
+++ b/src/chartConfig/index.js
@@ -40,8 +40,8 @@ export const vaccineCharts = [
 	casesByVax,
 	hospitalByVax,
 	icuByVax,
-	dailyDoses,
 	vaccinatedByAge,
+	dailyDoses,
 	totalDoses,
 	totalVaccinated,
 ];

--- a/src/chartConfig/vaccinations/casesByVax.js
+++ b/src/chartConfig/vaccinations/casesByVax.js
@@ -13,7 +13,7 @@ const casesByVax = {
   dataKeyX: 'date',
   title: 'Cases by vaccination status (per million)',
   leftYAxisLabel: 'New cases per million',
-	rightYAxisLabel: '2 dose effectiveness',
+  rightYAxisLabel: '2 dose effectiveness',
   xAxisScale: 'band',
   roundUpYAxisMax: true,
   footnote: footnote,

--- a/src/chartConfig/vaccinations/casesByVax.js
+++ b/src/chartConfig/vaccinations/casesByVax.js
@@ -1,9 +1,23 @@
 import vaccineCharts from './vaccineChartIDs';
+import { Fragment } from 'react';
+
+const footnote = <Fragment>
+* This data is population adjusted.<br/>
+* Population denominators are calculated based on daily dose history.<br/>
+* <b>Fully vaccinated</b> = 14 days after 2nd dose<br/>
+* <b>Partially vaccinated</b> = 14 days after 1st dose and &lt;14 days after 2nd dose.
+</Fragment>;
 
 const casesByVax = {
   id: vaccineCharts.casesByVax,
   dataKeyX: 'date',
   title: 'Cases by vaccination status (per million)',
+  leftYAxisLabel: 'New cases per million',
+	rightYAxisLabel: '2 dose effectiveness',
+  xAxisScale: 'band',
+  roundUpYAxisMax: true,
+  footnote: footnote,
+  rightValueSuffix: '%',
   areas: [
     {
       dataKey: 'cases_full_vax_per_mil',
@@ -33,6 +47,16 @@ const casesByVax = {
       type:'monotone'
     },
   ],
+  lines: [
+    {
+      dataKey: 'cases_full_effect',
+      name: '2 Dose Effectiveness',
+      stroke: '#000000',
+      strokeWidth: 2,
+      type: 'monotone',
+      yAxisId: 'right',
+    }
+  ]
 };
 
 export default casesByVax;

--- a/src/chartConfig/vaccinations/dailyDoses.js
+++ b/src/chartConfig/vaccinations/dailyDoses.js
@@ -4,6 +4,7 @@ const dailyDoses = {
   id: vaccineCharts.dailyDoses,
   dataKeyX: 'date_string',
   title: 'Daily vaccines administered',
+  syncId: 'vaccineCharts',
   bars: [
     {
       dataKey: 'previous_day_first_doses_administered',

--- a/src/chartConfig/vaccinations/hospitalByVax.js
+++ b/src/chartConfig/vaccinations/hospitalByVax.js
@@ -1,9 +1,23 @@
 import vaccineCharts from './vaccineChartIDs';
+import { Fragment } from 'react';
+
+const footnote = <Fragment>
+* This data is population adjusted.<br/>
+* Population denominators are calculated based on daily dose history.<br/>
+* <b>Fully vaccinated</b> = 14 days after 2nd dose<br/>
+* <b>Partially vaccinated</b> = 14 days after 1st dose and &lt;14 days after 2nd dose.
+</Fragment>;
 
 const hospitalByVax = {
   id: vaccineCharts.hospitalByVax,
   dataKeyX: 'date',
   title: 'Hospital occupancy by vaccination status (per million)',
+  leftYAxisLabel: 'Hospital occupancy per million',
+	rightYAxisLabel: '2 dose effectiveness',
+  xAxisScale: 'band',
+  roundUpYAxisMax: true,
+  footnote: footnote,
+  rightValueSuffix: '%',
   areas: [
     {
       dataKey: 'hosp_full_vax_per_mil',
@@ -33,6 +47,16 @@ const hospitalByVax = {
       type:'monotone'
     },
   ],
+  lines: [
+    {
+      dataKey: 'hosp_full_effect',
+      name: '2 Dose Effectiveness',
+      stroke: '#000000',
+      strokeWidth: 2,
+      type: 'monotone',
+      yAxisId: 'right',
+    }
+  ]
 };
 
 export default hospitalByVax;

--- a/src/chartConfig/vaccinations/hospitalByVax.js
+++ b/src/chartConfig/vaccinations/hospitalByVax.js
@@ -13,7 +13,7 @@ const hospitalByVax = {
   dataKeyX: 'date',
   title: 'Hospital occupancy by vaccination status (per million)',
   leftYAxisLabel: 'Hospital occupancy per million',
-	rightYAxisLabel: '2 dose effectiveness',
+  rightYAxisLabel: '2 dose effectiveness',
   xAxisScale: 'band',
   roundUpYAxisMax: true,
   footnote: footnote,

--- a/src/chartConfig/vaccinations/icuByVax.js
+++ b/src/chartConfig/vaccinations/icuByVax.js
@@ -1,9 +1,23 @@
 import vaccineCharts from './vaccineChartIDs';
+import { Fragment } from 'react';
+
+const footnote = <Fragment>
+* This data is population adjusted.<br/>
+* Population denominators are calculated based on daily dose history.<br/>
+* <b>Fully vaccinated</b> = 14 days after 2nd dose<br/>
+* <b>Partially vaccinated</b> = 14 days after 1st dose and &lt;14 days after 2nd dose.
+</Fragment>;
 
 const icuByVax = {
   id: vaccineCharts.icuByVax,
   dataKeyX: 'date',
   title: 'ICU occupancy by vaccination status (per million)',
+  leftYAxisLabel: 'ICU occupancy per million',
+	rightYAxisLabel: '2 dose effectiveness',
+  xAxisScale: 'band',
+  roundUpYAxisMax: true,
+  footnote: footnote,
+  rightValueSuffix: '%',
   areas: [
     {
       dataKey: 'icu_full_vax_per_mil',
@@ -33,6 +47,16 @@ const icuByVax = {
       type:'monotone'
     },
   ],
+  lines: [
+    {
+      dataKey: 'icu_full_effect',
+      name: '2 Dose Effectiveness',
+      stroke: '#000000',
+      strokeWidth: 2,
+      type: 'monotone',
+      yAxisId: 'right',
+    }
+  ]
 };
 
 export default icuByVax;

--- a/src/chartConfig/vaccinations/icuByVax.js
+++ b/src/chartConfig/vaccinations/icuByVax.js
@@ -13,7 +13,7 @@ const icuByVax = {
   dataKeyX: 'date',
   title: 'ICU occupancy by vaccination status (per million)',
   leftYAxisLabel: 'ICU occupancy per million',
-	rightYAxisLabel: '2 dose effectiveness',
+  rightYAxisLabel: '2 dose effectiveness',
   xAxisScale: 'band',
   roundUpYAxisMax: true,
   footnote: footnote,

--- a/src/chartConfig/vaccinations/totalDoses.js
+++ b/src/chartConfig/vaccinations/totalDoses.js
@@ -4,6 +4,7 @@ const totalDoses = {
 	id: vaccineCharts.totalDoses,
 	dataKeyX: 'date_string',
 	title: 'Total vaccines administered',
+	syncId: 'vaccineCharts',
 	areas: [{
 		dataKey: 'total_doses_administered',
 		name: 'Total doses administered',

--- a/src/chartConfig/vaccinations/totalVaccinated.js
+++ b/src/chartConfig/vaccinations/totalVaccinated.js
@@ -4,6 +4,7 @@ const totalVaccinated = {
 	id: vaccineCharts.totalVaccinated,
 	dataKeyX: 'date_string',
 	title: 'Total people fully vaccinated',
+	syncId: 'vaccineCharts',
 	areas: [{
 		dataKey: 'total_individuals_fully_vaccinated',
 		name: 'Total people fully vaccinated',

--- a/src/chartConfig/vaccinations/vaccinatedByAge.js
+++ b/src/chartConfig/vaccinations/vaccinatedByAge.js
@@ -4,6 +4,9 @@ const vaccinatedByAge = {
   id: vaccineCharts.vaccinatedByAge,
   dataKeyX: 'Agegroup',
   title: 'Vaccination rate by age group',
+  xAxisScale: 'band',
+  leftValueSuffix: '%',
+	yAxisTicks: [0, 25, 50, 80, 90, 100],
   bars: [
     {
       dataKey: 'Percent_fully_vaccinated',

--- a/src/chartConfig/vaccinations/vaccinatedByAge.js
+++ b/src/chartConfig/vaccinations/vaccinatedByAge.js
@@ -6,7 +6,7 @@ const vaccinatedByAge = {
   title: 'Vaccination rate by age group',
   xAxisScale: 'band',
   leftValueSuffix: '%',
-	yAxisTicks: [0, 25, 50, 80, 90, 100],
+  yAxisTicks: [0, 25, 50, 80, 90, 100],
   bars: [
     {
       dataKey: 'Percent_fully_vaccinated',

--- a/src/components/ChartContainer.js
+++ b/src/components/ChartContainer.js
@@ -70,7 +70,7 @@ const ChartContainer = ({
 						yAxisId="right" 
 						orientation="right" 
 						tickFormatter={tick => tick.toLocaleString() + rightValueSuffix}
-						label={{ value: rightYAxisLabel, angle: -90, position: 'insideRight' , style: { textAnchor: 'middle' }}}
+						label={{ value: rightYAxisLabel, angle: -90, position: 'insideRight' , style: { textAnchor: 'middle' } }}
 						/>
 					}
 					<Tooltip formatter={ (value, name) => value.toLocaleString() + getSuffix(name)} labelFormatter={(value) => (xLabel ? `${xLabel}: ` : '') + value}/>

--- a/src/components/ChartContainer.js
+++ b/src/components/ChartContainer.js
@@ -17,16 +17,27 @@ const ChartContainer = ({
 	syncId,
 	xAxisScale,
 	xLabel,
-	valueSuffix = '',
+	leftValueSuffix = '',
+	rightValueSuffix = '',
 	roundUpYAxisMax = false,
 	footnote = '',
-	yAxisTicks
+	yAxisTicks,
+	leftYAxisLabel,
+	rightYAxisLabel
 }) => {
 
 	let domain = [0, 'auto'];
 	if (roundUpYAxisMax) {
 		domain = [0, dataMax => Math.ceil(dataMax / 2) * 2];
 	}
+
+	const getSuffix = (name) => {
+		const foundElement = areas.find(a => a.name == name) || bars.find(a => a.name == name) || lines.find(a => a.name == name);
+		if (foundElement?.yAxisId == 'right') {
+			return rightValueSuffix;
+		}
+		return leftValueSuffix;
+	};
 
 	return (
 		<ContentContainer title={title} footnote={footnote}>
@@ -47,24 +58,34 @@ const ChartContainer = ({
 						)}
 					</XAxis>
 					<YAxis
+						yAxisId='left'
 						type="number"
 						domain={domain}
 						ticks={yAxisTicks}
-						tickFormatter={tick => tick.toLocaleString() + valueSuffix}
+						tickFormatter={tick => tick.toLocaleString() + leftValueSuffix}
+						label={leftYAxisLabel ? { value: leftYAxisLabel, angle: -90, position: 'insideLeft', style: { textAnchor: 'middle' } } : null}
 					/>
-					<Tooltip formatter={(value) => value.toLocaleString() + valueSuffix} labelFormatter={(value) => (xLabel ? `${xLabel}: ` : '') + value}/>
+					{rightYAxisLabel && 
+					<YAxis 
+						yAxisId="right" 
+						orientation="right" 
+						tickFormatter={tick => tick.toLocaleString() + rightValueSuffix}
+						label={{ value: rightYAxisLabel, angle: -90, position: 'insideRight' , style: { textAnchor: 'middle' }}}
+						/>
+					}
+					<Tooltip formatter={ (value, name) => value.toLocaleString() + getSuffix(name)} labelFormatter={(value) => (xLabel ? `${xLabel}: ` : '') + value}/>
 					{bars.map(bar => (
-						<Bar key={bar.dataKey} stackId='a' {...bar} />
+						<Bar key={bar.dataKey} stackId='a' yAxisId='left' {...bar} />
 					))}
 					{lines.map((line) => (
-						<Line key={line.dataKey} {...line}>
+						<Line key={line.dataKey} yAxisId='left' {...line}>
 							{line.errorBarKey && (
 								<ErrorBar dataKey="error_bars" direction="y" width={2} />
 							)}
 						</Line>
 					))}
 					{areas.map((area) => (
-						<Area key={area.dataKey} {...area} />
+						<Area key={area.dataKey} yAxisId='left' {...area} />
 					))}
 				</ComposedChart>
 			</ResponsiveContainer>

--- a/src/components/ChartContainer.js
+++ b/src/components/ChartContainer.js
@@ -19,7 +19,8 @@ const ChartContainer = ({
 	xLabel,
 	valueSuffix = '',
 	roundUpYAxisMax = false,
-	footnote = ''
+	footnote = '',
+	yAxisTicks
 }) => {
 
 	let domain = [0, 'auto'];
@@ -48,6 +49,7 @@ const ChartContainer = ({
 					<YAxis
 						type="number"
 						domain={domain}
+						ticks={yAxisTicks}
 						tickFormatter={tick => tick.toLocaleString() + valueSuffix}
 					/>
 					<Tooltip formatter={(value) => value.toLocaleString() + valueSuffix} labelFormatter={(value) => (xLabel ? `${xLabel}: ` : '') + value}/>

--- a/src/data/getVaccineAgeData.js
+++ b/src/data/getVaccineAgeData.js
@@ -1,7 +1,7 @@
 import jsonpFetch from './jsonpFetch';
 
 const dataUrl =
-  'https://data.ontario.ca/api/3/action/datastore_search?resource_id=775ca815-5028-4e9b-9dd4-6975ff1be021&limit=10&sort=_id desc';
+  'https://data.ontario.ca/api/3/action/datastore_search?resource_id=775ca815-5028-4e9b-9dd4-6975ff1be021&limit=11&sort=_id desc';
 
 const ensureNumber = (value) => {
     if (typeof value === 'number') {
@@ -28,6 +28,8 @@ const beautifyAge = (age) => {
       return '70s';
     case 'Adults_18plus':
       return '18+';
+    case 'Ontario_12plus':
+      return '12+';
     default: 
       return age;
   }

--- a/src/pages/vaccinations.js
+++ b/src/pages/vaccinations.js
@@ -59,7 +59,7 @@ const VaccinationsContainer = () => {
 				return data;
 			default: 
 				return [];
-		}
+		};
 	}
 
 	return (

--- a/src/pages/vaccinations.js
+++ b/src/pages/vaccinations.js
@@ -65,12 +65,13 @@ const VaccinationsContainer = () => {
 						<VaccineStatusTable dataSource={data} />
 						<VaccineEffectTable dataSource={vaxEffectData.avg} />
 						{vaccineCharts.map((chart, index) => {
-							let dataSource, syncId, xAxisScale, valueSuffix, footnote, roundUpYAxisMax;
+							let dataSource, syncId, xAxisScale, valueSuffix, footnote, roundUpYAxisMax, yAxisTicks;
 							if (chart.id == chartIDs.vaccinatedByAge) {
 								dataSource = ageData;
 								syncId = 'vaccineAgeCharts';
 								xAxisScale = 'band';
 								valueSuffix = '%';
+								yAxisTicks = [0, 25, 50, 80, 90, 100];
 							} else if ([chartIDs.casesByVax, chartIDs.hospitalByVax, chartIDs.icuByVax].includes(chart.id)) {
 								dataSource = vaxEffectData.all;
 								if ([chartIDs.hospitalByVax, chartIDs.icuByVax].includes(chart.id)) {
@@ -92,6 +93,7 @@ const VaccinationsContainer = () => {
 												footnote={footnote}
 												roundUpYAxisMax={roundUpYAxisMax}
 												valueSuffix={valueSuffix}
+												yAxisTicks={yAxisTicks}
 												{...chart}
 											/>;
 						})}

--- a/src/pages/vaccinations.js
+++ b/src/pages/vaccinations.js
@@ -58,11 +58,9 @@ const VaccinationsContainer = () => {
 			case chartIDs.dailyDoses:
 				return data;
 			default: 
-				return null;
+				return [];
 		}
 	}
-
-	// const vaxEffectFootnote = <Fragment>* This data is population adjusted. <br/>* Population denominators are calculated based on daily dose history.<br/>* <b>Fully vaccinated</b> = 14 days after 2nd dose<br/>* <b>Partially vaccinated</b> = 14 days after 1st dose and &lt;14 days after 2nd dose.</Fragment>;
 
 	return (
 		<Layout menuItems={menuItems}>

--- a/src/pages/vaccinations.js
+++ b/src/pages/vaccinations.js
@@ -59,8 +59,8 @@ const VaccinationsContainer = () => {
 				return data;
 			default: 
 				return [];
-		};
-	}
+		}
+	};
 
 	return (
 		<Layout menuItems={menuItems}>

--- a/src/pages/vaccinations.js
+++ b/src/pages/vaccinations.js
@@ -42,7 +42,27 @@ const VaccinationsContainer = () => {
 		}))
 	];
 
-	const vaxEffectFootnote = <Fragment>* This data is population adjusted. <br/>* Population denominators are calculated based on daily dose history.<br/>* <b>Fully vaccinated</b> = 14 days after 2nd dose<br/>* <b>Partially vaccinated</b> = 14 days after 1st dose and &lt;14 days after 2nd dose.</Fragment>;
+	// Returns the right set of data for the given chart ID
+	const getData = (chartID) => {
+		switch (chartID)
+		{
+			case chartIDs.vaccinatedByAge:
+				return ageData;
+			case chartIDs.casesByVax:
+				return vaxEffectData.all;
+			case chartIDs.hospitalByVax:
+			case chartIDs.icuByVax: 
+				return vaxEffectData.all.filter(item => item.hosp_unvax_per_mil != null);
+			case chartIDs.totalDoses:
+			case chartIDs.totalVaccinated:
+			case chartIDs.dailyDoses:
+				return data;
+			default: 
+				return null;
+		}
+	}
+
+	// const vaxEffectFootnote = <Fragment>* This data is population adjusted. <br/>* Population denominators are calculated based on daily dose history.<br/>* <b>Fully vaccinated</b> = 14 days after 2nd dose<br/>* <b>Partially vaccinated</b> = 14 days after 1st dose and &lt;14 days after 2nd dose.</Fragment>;
 
 	return (
 		<Layout menuItems={menuItems}>
@@ -65,35 +85,9 @@ const VaccinationsContainer = () => {
 						<VaccineStatusTable dataSource={data} />
 						<VaccineEffectTable dataSource={vaxEffectData.avg} />
 						{vaccineCharts.map((chart, index) => {
-							let dataSource, syncId, xAxisScale, valueSuffix, footnote, roundUpYAxisMax, yAxisTicks;
-							if (chart.id == chartIDs.vaccinatedByAge) {
-								dataSource = ageData;
-								syncId = 'vaccineAgeCharts';
-								xAxisScale = 'band';
-								valueSuffix = '%';
-								yAxisTicks = [0, 25, 50, 80, 90, 100];
-							} else if ([chartIDs.casesByVax, chartIDs.hospitalByVax, chartIDs.icuByVax].includes(chart.id)) {
-								dataSource = vaxEffectData.all;
-								if ([chartIDs.hospitalByVax, chartIDs.icuByVax].includes(chart.id)) {
-									dataSource = dataSource.filter(item => item.hosp_unvax_per_mil != null);
-								}
-								xAxisScale = 'band';
-								roundUpYAxisMax = true;
-								footnote = vaxEffectFootnote;
-							} else {
-								dataSource = data;
-								syncId = 'vaccineCharts';
-							}
-
 							return <ChartContainer
 												key={index}
-												dataSource={dataSource}
-												syncId={syncId}
-												xAxisScale={xAxisScale}
-												footnote={footnote}
-												roundUpYAxisMax={roundUpYAxisMax}
-												valueSuffix={valueSuffix}
-												yAxisTicks={yAxisTicks}
+												dataSource={getData(chart.id)}
 												{...chart}
 											/>;
 						})}


### PR DESCRIPTION
I just added the daily vaccine effectiveness to the charts. 
I also fixed a couple of things in the vax age breakdown chart:
- Ontario added a new age group (12+), so the first group (12-17) wasn't showing up anymore.
- I changed the the y axis to show 80% and 90%, instead of 75%.

P.S: I know you're busy, this should be the last PR for a while.

![Screen Shot 2021-09-01 at 2 33 20 PM](https://user-images.githubusercontent.com/7216646/131727182-690ece46-c687-41d2-9eef-ca29771369b1.png)
![Screen Shot 2021-09-01 at 2 56 02 PM](https://user-images.githubusercontent.com/7216646/131727998-1078dcad-c3d9-4244-98b2-f47b91220a77.png)

